### PR TITLE
feat: patent links to USPTO and Google Patents

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -566,7 +566,39 @@ body {
 
 .card-footer {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
+    align-items: center;
+}
+
+.patent-links {
+    display: flex;
+    gap: 0.5rem;
+    margin-left: auto;
+}
+
+.patent-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-decoration: none;
+    padding: 0.2rem 0.45rem;
+    border: 1px solid var(--card-border);
+    border-radius: 2px;
+    background-color: var(--bg-primary);
+    transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.patent-link:hover {
+    color: var(--accent-blue);
+    border-color: var(--accent-blue);
+}
+
+.patent-link i {
+    font-size: 0.65rem;
 }
 
 .patent-tag {

--- a/index.html
+++ b/index.html
@@ -168,6 +168,10 @@
                         <div class="card-footer">
                             <span class="patent-tag">Orchestration</span>
                             <span class="patent-tag">High Availability</span>
+                            <div class="patent-links">
+                                <a href="https://patents.uspto.gov/patent/12639100" target="_blank" rel="noopener" class="patent-link" aria-label="View on USPTO">USPTO <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                                <a href="https://patents.google.com/patent/US12639100B2" target="_blank" rel="noopener" class="patent-link" aria-label="View on Google Patents">Google Patents <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                            </div>
                         </div>
                     </div>
 
@@ -186,6 +190,10 @@
                         <div class="card-footer">
                             <span class="patent-tag">Rollout Orchestration</span>
                             <span class="patent-tag">Fleet Management</span>
+                            <div class="patent-links">
+                                <a href="https://patents.uspto.gov/patent/19056415" target="_blank" rel="noopener" class="patent-link" aria-label="View on USPTO">USPTO <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                                <a href="https://patents.google.com/patent/US20250156415A1" target="_blank" rel="noopener" class="patent-link" aria-label="View on Google Patents">Google Patents <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                            </div>
                         </div>
                     </div>
 
@@ -204,6 +212,10 @@
                         <div class="card-footer">
                             <span class="patent-tag">Distributed Systems</span>
                             <span class="patent-tag">Zero Downtime Upgrades</span>
+                            <div class="patent-links">
+                                <a href="https://patents.uspto.gov/patent/11983524" target="_blank" rel="noopener" class="patent-link" aria-label="View on USPTO">USPTO <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                                <a href="https://patents.google.com/patent/US11983524B2" target="_blank" rel="noopener" class="patent-link" aria-label="View on Google Patents">Google Patents <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
Added USPTO and Google Patents links to all three patent cards.

## Changes
- : Added  and  styles (bordered pills matching design system)
- : Added dual links to each patent card footer

## Note
Patent 2 (US 19/056,415) is a patent application - Google Patents link uses a placeholder publication number. You'll need to verify/update the correct Google Patents URL for this application.