### PR TITLE
feat: skills/tech stack visualization section

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -505,6 +505,94 @@ body {
 }
 
 /* ==========================================================================
+   Skills / Tech Stack Section
+   ========================================================================== */
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1.5rem;
+}
+
+.skill-category {
+    display: flex;
+    flex-direction: column;
+}
+
+.skill-category-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--card-border);
+}
+
+.skill-category-title i {
+    color: var(--accent-blue);
+    font-size: 0.95rem;
+}
+
+.skill-chips {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.skill-chip {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    background-color: rgba(59, 130, 246, 0.04);
+    border: 1px solid rgba(59, 130, 246, 0.08);
+    border-radius: 4px;
+    transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.skill-chip:hover {
+    border-color: rgba(59, 130, 246, 0.2);
+    background-color: rgba(59, 130, 246, 0.07);
+}
+
+.skill-name {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.skill-dots {
+    display: flex;
+    gap: 4px;
+}
+
+.dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--card-border);
+    transition: background-color var(--transition-fast);
+}
+
+.dot.filled {
+    background-color: var(--accent-blue);
+}
+
+/* Reveal Animation */
+.reveal {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* ==========================================================================
    Patents Section
    ========================================================================== */
 .patents-grid {
@@ -821,6 +909,11 @@ body {
     }
 
     .patents-grid {
+        grid-template-columns: 1fr;
+        gap: 1.25rem;
+    }
+
+    .skills-grid {
         grid-template-columns: 1fr;
         gap: 1.25rem;
     }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -118,4 +118,22 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('scroll', scrollActive);
     // Trigger scroll spy on load
     scrollActive();
+
+    // ==========================================================================
+    // Reveal on Scroll: IntersectionObserver for .reveal elements
+    // ==========================================================================
+    if ('IntersectionObserver' in window) {
+        const revealElements = document.querySelectorAll('.reveal');
+        if (revealElements.length > 0) {
+            const revealObserver = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('visible');
+                        revealObserver.unobserve(entry.target);
+                    }
+                });
+            }, { threshold: 0.15 });
+            revealElements.forEach(el => revealObserver.observe(el));
+        }
+    }
 });

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
             <nav class="nav" id="nav-menu" role="navigation" aria-label="Main Navigation">
                 <ul class="nav-list">
                     <li><a href="#about" class="nav-link active">About</a></li>
+                    <li><a href="#skills" class="nav-link">Skills</a></li>
                     <li><a href="#patents" class="nav-link">Patents</a></li>
                     <li><a href="#research" class="nav-link">Research</a></li>
                     <li><a href="#projects" class="nav-link">Projects</a></li>
@@ -137,6 +138,162 @@
                     <div class="profile-card">
                         <div class="profile-img-frame">
                             <img src="images/me.jpg" alt="Sahil Gandhi" class="profile-img" loading="lazy" decoding="async">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Skills / Tech Stack Section -->
+        <section id="skills" class="skills section" aria-labelledby="skills-title">
+            <div class="container">
+                <div class="section-header">
+                    <span class="section-tagline">Expertise</span>
+                    <h2 class="section-title" id="skills-title">Skills & Tech Stack</h2>
+                    <p class="section-desc">Core technologies and tools I work with across distributed systems, cloud infrastructure, and full-stack development.</p>
+                </div>
+
+                <div class="skills-grid">
+                    <!-- Languages -->
+                    <div class="skill-category card reveal" role="article">
+                        <h3 class="skill-category-title"><i class="fa-solid fa-code"></i> Languages</h3>
+                        <div class="skill-chips">
+                            <div class="skill-chip">
+                                <span class="skill-name">Go</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Python</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Java</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">C/C++</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">JavaScript/TypeScript</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">SQL</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Frameworks -->
+                    <div class="skill-category card reveal" role="article">
+                        <h3 class="skill-category-title"><i class="fa-solid fa-layer-group"></i> Frameworks</h3>
+                        <div class="skill-chips">
+                            <div class="skill-chip">
+                                <span class="skill-name">gRPC</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Kafka</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Kubernetes</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">React</span>
+                                <span class="skill-dots" aria-label="3 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Node.js</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Infrastructure -->
+                    <div class="skill-category card reveal" role="article">
+                        <h3 class="skill-category-title"><i class="fa-solid fa-cloud"></i> Infrastructure</h3>
+                        <div class="skill-chips">
+                            <div class="skill-chip">
+                                <span class="skill-name">AWS</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">GCP</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Docker</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Terraform</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Prometheus</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Grafana</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Databases -->
+                    <div class="skill-category card reveal" role="article">
+                        <h3 class="skill-category-title"><i class="fa-solid fa-database"></i> Databases</h3>
+                        <div class="skill-chips">
+                            <div class="skill-chip">
+                                <span class="skill-name">PostgreSQL</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Cassandra</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Redis</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Kafka</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">etcd</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Tools -->
+                    <div class="skill-category card reveal" role="article">
+                        <h3 class="skill-category-title"><i class="fa-solid fa-screwdriver-wrench"></i> Tools</h3>
+                        <div class="skill-chips">
+                            <div class="skill-chip">
+                                <span class="skill-name">Git</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">CI/CD</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Linux</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Bazel</span>
+                                <span class="skill-dots" aria-label="4 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot"></span></span>
+                            </div>
+                            <div class="skill-chip">
+                                <span class="skill-name">Protobuf</span>
+                                <span class="skill-dots" aria-label="5 out of 5 proficiency"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
Added Skills/Tech Stack section between About and Patents with 5 categories and proficiency indicators.

## Changes
- : Skills nav link + section with 5 category cards (Languages, Frameworks, Infrastructure, Databases, Tools), each with skill chips showing 5-dot proficiency
- : Skills grid, chip styles, dot proficiency indicators, responsive collapse
- : IntersectionObserver for reveal animations

## Skills included
- Languages: Go, Python, Java, C/C++, JavaScript/TypeScript, SQL
- Frameworks: gRPC, Kafka, Kubernetes, React, Node.js
- Infrastructure: AWS, GCP, Docker, Terraform, Prometheus, Grafana
- Databases: PostgreSQL, Cassandra, Redis, Kafka, etcd
- Tools: Git, CI/CD, Linux, Bazel, Protobuf