### PR TITLE
feat: service worker with Workbox (offline caching, stale-while-revalidate)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -118,4 +118,11 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('scroll', scrollActive);
     // Trigger scroll spy on load
     scrollActive();
+
+    // ==========================================================================
+    // Service Worker Registration
+    // ==========================================================================
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js').catch(() => {});
+    }
 });

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Offline — Sahil Gandhi</title>
+    <meta name="theme-color" content="#0b0f19">
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            background: #0b0f19;
+            color: #e2e8f0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .offline-container {
+            text-align: center;
+            padding: 2rem;
+            max-width: 480px;
+        }
+
+        .offline-icon {
+            font-size: 4rem;
+            margin-bottom: 1.5rem;
+        }
+
+        h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 0.75rem;
+            color: #f8fafc;
+        }
+
+        p {
+            font-size: 1rem;
+            line-height: 1.6;
+            color: #94a3b8;
+            margin-bottom: 2rem;
+        }
+
+        .retry-btn {
+            display: inline-block;
+            padding: 0.75rem 2rem;
+            background: #6366f1;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            font-size: 1rem;
+            font-weight: 500;
+            cursor: pointer;
+            text-decoration: none;
+            transition: background 0.2s;
+        }
+
+        .retry-btn:hover { background: #4f46e5; }
+    </style>
+</head>
+<body>
+    <div class="offline-container">
+        <div class="offline-icon">&#128268;</div>
+        <h1>You're offline</h1>
+        <p>It looks like you've lost your internet connection. Please check your network and try again.</p>
+        <button class="retry-btn" onclick="location.reload()">Retry</button>
+    </div>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,74 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/7.1.0/workbox-sw.js');
+
+const { Routing, Strategies, Expiration, CacheableResponse } = workbox;
+const { NetworkFirst, StaleWhileRevalidate, CacheFirst } = Strategies;
+const { ExpirationPlugin } = Expiration;
+const { CacheableResponsePlugin } = CacheableResponse;
+
+const OFFLINE_FALLBACK = '/offline.html';
+const CACHE_VERSION = 'v1';
+
+// Skip waiting and claim clients immediately
+self.skipWaiting();
+self.addEventListener('activate', (event) => {
+  event.waitUntil(clients.claim());
+});
+
+// HTML pages — NetworkFirst (fresh content, offline fallback)
+Routing.registerRoute(
+  ({ request }) => request.destination === 'html',
+  new NetworkFirst({
+    cacheName: `pages-${CACHE_VERSION}`,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 7 * 24 * 60 * 60 }),
+    ],
+  })
+);
+
+// CSS & JS — StaleWhileRevalidate (serve cache fast, update in background)
+Routing.registerRoute(
+  ({ request }) => request.destination === 'style' || request.destination === 'script',
+  new StaleWhileRevalidate({
+    cacheName: `static-${CACHE_VERSION}`,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 30 * 24 * 60 * 60 }),
+    ],
+  })
+);
+
+// Images — CacheFirst (long-term)
+Routing.registerRoute(
+  ({ request }) => request.destination === 'image',
+  new CacheFirst({
+    cacheName: `images-${CACHE_VERSION}`,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 90 * 24 * 60 * 60 }),
+    ],
+  })
+);
+
+// Fonts (local + Google Fonts) — CacheFirst (long-term)
+Routing.registerRoute(
+  ({ request }) => request.destination === 'font',
+  new CacheFirst({
+    cacheName: `fonts-${CACHE_VERSION}`,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 180 * 24 * 60 * 60 }),
+    ],
+  })
+);
+
+// Fallback to offline page for navigation requests when network fails
+self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => {
+        return caches.match(OFFLINE_FALLBACK);
+      })
+    );
+  }
+});


### PR DESCRIPTION
## Summary
Added Workbox service worker with comprehensive caching strategies for offline support.

## Changes
- : Workbox v7.1.0 with NetworkFirst (HTML), StaleWhileRevalidate (CSS/JS), CacheFirst (images/fonts), offline fallback
- : Self-contained offline page matching site theme
- : SW registration with feature detection

## Caching strategies
- HTML: NetworkFirst (always fresh)
- CSS/JS: StaleWhileRevalidate (fast + fresh)
- Images/Fonts: CacheFirst (long-term)
- Offline navigation fallback to offline.html