### PR TITLE
feat: resource hints (preload, prefetch, dns-prefetch)

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,21 @@
         }
     }
     </script>
+    <!-- Preload critical resources -->
+    <link rel="preload" href="images/me.jpg" as="image">
+    <link rel="preload" href="assets/css/main.css" as="style">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" as="style" crossorigin>
+    <!-- Prefetch non-critical resources -->
+    <link rel="prefetch" href="resume.pdf">
+    <link rel="prefetch" href="cv.pdf">
+    <link rel="prefetch" href="whitepapers/Xldb.pdf">
+    <link rel="prefetch" href="whitepapers/IoTShark.pdf">
+    <link rel="prefetch" href="whitepapers/SIKE.pdf">
+    <link rel="prefetch" href="whitepapers/PKEG.pdf">
+    <!-- DNS-Prefetch for external domains -->
+    <link rel="dns-prefetch" href="https://github.com">
+    <link rel="dns-prefetch" href="https://linkedin.com">
+    <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
Added resource hints for faster page loads.

## Changes
- : 18 link tags in head:
  - preload: hero image, main.css, Google Fonts
  - prefetch: resume.pdf, cv.pdf, 4 whitepaper PDFs
  - dns-prefetch: github.com, linkedin.com, cdnjs.cloudflare.com
  - preconnect: fonts.googleapis.com, fonts.gstatic.com (existing)